### PR TITLE
fix: rename commands_count to orders_count in CustomersTableList and …

### DIFF
--- a/src/components/Intranet/Clients/CustomersTableList.tsx
+++ b/src/components/Intranet/Clients/CustomersTableList.tsx
@@ -145,7 +145,7 @@ export default function CustomersTableList({
                                 </p>
                             </TableCell>
                             <TableCell>
-                                <p>{customer.commands_count}</p>
+                                <p>{customer.orders_count}</p>
                             </TableCell>
                             <TableCell>
                                 <ThreeDotMenu

--- a/src/pages/CustomersPage.tsx
+++ b/src/pages/CustomersPage.tsx
@@ -15,6 +15,7 @@ import UsersProvider from "@core/api/Providers/UsersProvider.ts";
 import { useGlobalAlert } from "@/contexts/GlobalAlertContext.tsx";
 import { useSort } from "@utils/hook/useSort.ts";
 import { usePagination } from "@utils/hook/usePagination.ts";
+import i18n from "@/core/i18n/i18n";
 
 const fetchCustomers = async (key: string): Promise<PaginatedCustomers> => {
     const params = JSON.parse(key);
@@ -66,6 +67,7 @@ export default function CustomersPage() {
     ): Promise<void> => {
         try {
             formData.role_id = "4";
+            formData.locale = i18n.language;
             await UsersProvider.createUser(formData);
             await mutate();
             onOpenChange();

--- a/src/types/Customers.ts
+++ b/src/types/Customers.ts
@@ -12,7 +12,7 @@ export interface Customer {
         id: number;
         name: string;
     };
-    commands_count: number;
+    orders_count: number;
 }
 
 export interface PaginatedCustomers {


### PR DESCRIPTION
…update Customer type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Lors de l’ajout d’un client, la langue actuelle de l’interface est désormais incluse dans les données soumises.

- **Corrections**
  - Le tableau des clients affiche maintenant le nombre de commandes (« orders_count ») au lieu du nombre de commandes précédemment nommé (« commands_count »).

- **Refactorisation**
  - Renommage du champ « commands_count » en « orders_count » dans les données client pour une meilleure cohérence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->