### PR TITLE
fix: Update network name in docker-compose.yml for consistency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,3 +36,4 @@ services:
 networks:
   psl-network:
     external: true
+    name: psl-api_psl-network


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Mise à jour de la configuration docker-compose pour préciser explicitement le nom du réseau externe utilisé.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->